### PR TITLE
Update pyGenomeTracks version to 3.8 to resolve ValueError

### DIFF
--- a/env.yaml
+++ b/env.yaml
@@ -117,8 +117,8 @@ dependencies:
   - coverage=6.4.2
   - crashtest=0.3.1
   - cryptography=37.0.4
-#   - cudatoolkit=11.2.2=hbe64b41_10
-#   - cudnn=8.4.1.50=hed8a83a_0
+  #   - cudatoolkit=11.2.2=hbe64b41_10
+  #   - cudnn=8.4.1.50=hed8a83a_0
   - curl=7.83.1
   - cycler=0.11.0
   - cython=0.29.32
@@ -555,7 +555,7 @@ dependencies:
   - pydot=1.4.2
   - pyfaidx=0.7.1
   - pyflakes=2.2.0
-  - pygenometracks=3.7
+  - pygenometracks=3.8
   - pygithub=1.55
   - pygments=2.12.0
   - pygraphviz=1.9
@@ -770,12 +770,12 @@ dependencies:
   - zope.interface=5.4.0
   - zstd=1.5.2
   - pip:
-    - allcools==0.1.18
-    - anndata2ri==1.0.6
-    - ctxcore==0.2.0
-    - multiprocessing-on-dill==3.5.0a4
-    - packaging==21.3
-    - pyscenic==0.11.2
-    - rpy2==3.4.4
-#     - scglue==0.3.0
-    - velocyto==0.17.17
+      - allcools==0.1.18
+      - anndata2ri==1.0.6
+      - ctxcore==0.2.0
+      - multiprocessing-on-dill==3.5.0a4
+      - packaging==21.3
+      - pyscenic==0.11.2
+      - rpy2==3.4.4
+      #     - scglue==0.3.0
+      - velocyto==0.17.17


### PR DESCRIPTION
This issue was detailed in [Issue #99](https://github.com/gao-lab/GLUE/issues/99) and was identified when executing the tutorial's code snippet for generating visualization tracks. The problematic interval resulted from a midpoint calculation that inadvertently inverted the interval's start and end points.

By updating to `pyGenomeTracks` version `3.8`, this pull request seeks to prevent similar issues for future users attempting to run the tutorial. The update should be backward compatible with the existing tutorial code and data.

Thank you for considering this update to improve the usability of the tutorial.
